### PR TITLE
Update Sass modules

### DIFF
--- a/assets/scss/abstracts/_mixins.scss
+++ b/assets/scss/abstracts/_mixins.scss
@@ -5,8 +5,8 @@
 
 // Responsive breakpoints
 @mixin respond-to($breakpoint) {
-  @if map-has-key($breakpoints, $breakpoint) {
-    $value: map-get($breakpoints, $breakpoint);
+  @if map.has-key($breakpoints, $breakpoint) {
+    $value: map.get($breakpoints, $breakpoint);
     @media (min-width: #{$value}) {
       @content;
     }

--- a/assets/scss/editor.scss
+++ b/assets/scss/editor.scss
@@ -4,10 +4,10 @@
  */
 
 // Import base styles that should also apply in editor
-@import 'abstracts/variables';
-@import 'abstracts/functions';
-@import 'abstracts/mixins';
-@import 'base/typography';
+@use 'abstracts/variables' as *;
+@use 'abstracts/functions' as *;
+@use 'abstracts/mixins' as *;
+@use 'base/typography' as *;
 
 // Editor-specific styles
 .editor-styles-wrapper {

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -4,31 +4,31 @@
  */
 
 // Abstracts - Variables, functions, mixins
-@import 'abstracts/variables';
-@import 'abstracts/functions';
-@import 'abstracts/mixins';
+@use 'abstracts/variables' as *;
+@use 'abstracts/functions' as *;
+@use 'abstracts/mixins' as *;
 
 // Base - Reset, typography, base elements
-@import 'base/reset';
-@import 'base/typography';
-@import 'base/base';
+@use 'base/reset' as *;
+@use 'base/typography' as *;
+@use 'base/base' as *;
 
 // Layout - Header, footer, grid, navigation
-@import 'layout/header';
-@import 'layout/navigation';
-@import 'layout/footer';
-@import 'layout/grid';
+@use 'layout/header' as *;
+@use 'layout/navigation' as *;
+@use 'layout/footer' as *;
+@use 'layout/grid' as *;
 
 // Components - Reusable UI components
-@import 'components/buttons';
-@import 'components/forms';
-@import 'components/cards';
-@import 'components/modals';
-@import 'components/accessibility';
-@import 'components/performance';
-@import 'components/seo';
+@use 'components/buttons' as *;
+@use 'components/forms' as *;
+@use 'components/cards' as *;
+@use 'components/modals' as *;
+@use 'components/accessibility' as *;
+@use 'components/performance' as *;
+@use 'components/seo' as *;
 
 // Pages - Page-specific styles
-@import 'pages/home';
-@import 'pages/single';
-@import 'pages/archive';
+@use 'pages/home' as *;
+@use 'pages/single' as *;
+@use 'pages/archive' as *;


### PR DESCRIPTION
Aggiorna moduli Sass

- Sostituiti tutti gli `@import` con la nuova sintassi `@use`
- Aggiornata la mixin `respond-to` usando `map.has-key` e `map.get`
