### PR TITLE
Add page templates and dynamic sidebars

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,17 @@ add_action('zenstarter/before_header', 'my_custom_function');
 add_filter('zenstarter/assets_version', 'my_version_filter');
 ```
 
+## 🗂 Templates & Sidebars
+
+Zenstarter include tre template di pagina predefiniti in `/templates/`:
+
+- **Full Width** – contenuto a tutta larghezza senza sidebar
+- **Sidebar Left** – layout con barra laterale a sinistra
+- **Sidebar Right** – layout con barra laterale a destra
+
+Le nuove aree widget possono essere registrate in `inc/widgets.php` tramite
+`register_sidebar()` e richiamate nei template con `get_sidebar('nome')`.
+
 ## 📦 Estensioni
 
 ### WooCommerce

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,0 +1,29 @@
+# 📄 Templates e Sidebars
+
+Questa sezione illustra i template di pagina disponibili in **Zenstarter** e come gestire nuove aree widget.
+
+## Template Inclusi
+
+- `template-fullwidth.php` – layout a tutta larghezza senza sidebar
+- `template-sidebar-left.php` – sidebar posizionata a sinistra
+- `template-sidebar-right.php` – sidebar posizionata a destra
+
+Ogni file si trova nella cartella `/templates/` e segue la gerarchia di WordPress con le funzioni standard `get_header()` e `get_footer()`.
+
+## Creare una nuova Sidebar
+
+1. Apri `inc/widgets.php` e registra una nuova sidebar tramite `register_sidebar()`.
+2. Assegna un `id` univoco e personalizza i parametri HTML (`before_widget`, `after_widget`, ecc.).
+3. Richiama `dynamic_sidebar( 'tuo-id' )` all'interno di un file `sidebar-*.php` dedicato.
+
+## Utilizzo delle Sidebars nei Template
+
+Nei template personalizzati puoi includere la sidebar desiderata con:
+
+```php
+if ( is_active_sidebar( 'sidebar-right' ) ) {
+    get_sidebar( 'right' );
+}
+```
+
+Sostituisci `right` con il nome della sidebar registrata. In assenza di widget l'area non verrà mostrata.

--- a/functions.php
+++ b/functions.php
@@ -29,6 +29,7 @@ if (file_exists(ZENSTARTER_PATH . '/vendor/autoload.php')) {
 // Include block patterns and variations
 require_once get_template_directory() . '/inc/block-patterns.php';
 require_once get_template_directory() . '/inc/block-variations.php';
+require_once get_template_directory() . '/inc/widgets.php';
 
 // Bootstrap the theme
 if (class_exists('Theme\Core\Setup')) {

--- a/inc/widgets.php
+++ b/inc/widgets.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Register custom widget areas
+ *
+ * @package Zenstarter
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Register left and right sidebars
+ */
+function zenstarter_register_custom_sidebars() {
+    register_sidebar([
+        'name'          => __('Right Sidebar', 'zenstarter'),
+        'id'            => 'sidebar-right',
+        'description'   => __('Sidebar displayed on the right.', 'zenstarter'),
+        'before_widget' => '<section id="%1$s" class="widget %2$s">',
+        'after_widget'  => '</section>',
+        'before_title'  => '<h2 class="widget-title">',
+        'after_title'   => '</h2>',
+    ]);
+
+    register_sidebar([
+        'name'          => __('Left Sidebar', 'zenstarter'),
+        'id'            => 'sidebar-left',
+        'description'   => __('Sidebar displayed on the left.', 'zenstarter'),
+        'before_widget' => '<section id="%1$s" class="widget %2$s">',
+        'after_widget'  => '</section>',
+        'before_title'  => '<h2 class="widget-title">',
+        'after_title'   => '</h2>',
+    ]);
+}
+add_action('widgets_init', 'zenstarter_register_custom_sidebars');
+

--- a/sidebar-left.php
+++ b/sidebar-left.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Left Sidebar template
+ *
+ * @package Zenstarter
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!is_active_sidebar('sidebar-left')) {
+    return;
+}
+?>
+
+<aside id="secondary" class="widget-area sidebar-left" role="complementary" aria-label="<?php esc_attr_e('Left Sidebar', 'zenstarter'); ?>">
+    <?php do_action('zenstarter_before_sidebar'); ?>
+
+    <div class="sidebar-content">
+        <?php dynamic_sidebar('sidebar-left'); ?>
+    </div>
+
+    <?php do_action('zenstarter_after_sidebar'); ?>
+</aside>

--- a/sidebar-right.php
+++ b/sidebar-right.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Right Sidebar template
+ *
+ * @package Zenstarter
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!is_active_sidebar('sidebar-right')) {
+    return;
+}
+?>
+
+<aside id="secondary" class="widget-area sidebar-right" role="complementary" aria-label="<?php esc_attr_e('Right Sidebar', 'zenstarter'); ?>">
+    <?php do_action('zenstarter_before_sidebar'); ?>
+
+    <div class="sidebar-content">
+        <?php dynamic_sidebar('sidebar-right'); ?>
+    </div>
+
+    <?php do_action('zenstarter_after_sidebar'); ?>
+</aside>

--- a/templates/template-fullwidth.php
+++ b/templates/template-fullwidth.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Template Name: Full Width
+ *
+ * Page template with no sidebar
+ *
+ * @package Zenstarter
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+get_header(); ?>
+
+<main id="main-content" class="site-main" role="main">
+    <div class="container">
+        <?php
+        do_action('zenstarter_before_page_content');
+        ?>
+
+        <?php while (have_posts()) : the_post(); ?>
+            <article id="post-<?php the_ID(); ?>" <?php post_class('page-single'); ?>>
+                <?php if (has_post_thumbnail()) : ?>
+                    <div class="page-featured-image">
+                        <?php the_post_thumbnail('large', array(
+                            'loading' => 'eager',
+                            'alt' => the_title_attribute(array('echo' => false))
+                        )); ?>
+                    </div>
+                <?php endif; ?>
+
+                <header class="entry-header">
+                    <?php the_title('<h1 class="entry-title">', '</h1>'); ?>
+                </header>
+
+                <div class="entry-content">
+                    <?php
+                    the_content();
+                    wp_link_pages(array(
+                        'before' => '<div class="page-links">' . esc_html__('Pages:', 'zenstarter'),
+                        'after'  => '</div>',
+                    ));
+                    ?>
+                </div>
+            </article>
+
+            <?php
+            if (comments_open() || get_comments_number()) :
+                comments_template();
+            endif;
+            ?>
+        <?php endwhile; ?>
+
+        <?php do_action('zenstarter_after_page_content'); ?>
+    </div>
+</main>
+
+<?php get_footer(); ?>

--- a/templates/template-sidebar-left.php
+++ b/templates/template-sidebar-left.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Template Name: Sidebar Left
+ *
+ * Page template with sidebar on the left
+ *
+ * @package Zenstarter
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+get_header(); ?>
+
+<?php
+if (is_active_sidebar('sidebar-left')) {
+    get_sidebar('left');
+}
+?>
+
+<main id="main-content" class="site-main" role="main">
+    <div class="container">
+        <?php do_action('zenstarter_before_page_content'); ?>
+
+        <?php while (have_posts()) : the_post(); ?>
+            <article id="post-<?php the_ID(); ?>" <?php post_class('page-single'); ?>>
+                <?php if (has_post_thumbnail()) : ?>
+                    <div class="page-featured-image">
+                        <?php the_post_thumbnail('large', array(
+                            'loading' => 'eager',
+                            'alt' => the_title_attribute(array('echo' => false))
+                        )); ?>
+                    </div>
+                <?php endif; ?>
+
+                <header class="entry-header">
+                    <?php the_title('<h1 class="entry-title">', '</h1>'); ?>
+                </header>
+
+                <div class="entry-content">
+                    <?php
+                    the_content();
+                    wp_link_pages(array(
+                        'before' => '<div class="page-links">' . esc_html__('Pages:', 'zenstarter'),
+                        'after'  => '</div>',
+                    ));
+                    ?>
+                </div>
+            </article>
+
+            <?php
+            if (comments_open() || get_comments_number()) :
+                comments_template();
+            endif;
+            ?>
+        <?php endwhile; ?>
+
+        <?php do_action('zenstarter_after_page_content'); ?>
+    </div>
+</main>
+
+<?php get_footer(); ?>

--- a/templates/template-sidebar-right.php
+++ b/templates/template-sidebar-right.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Template Name: Sidebar Right
+ *
+ * Page template with sidebar on the right
+ *
+ * @package Zenstarter
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+get_header(); ?>
+
+<main id="main-content" class="site-main" role="main">
+    <div class="container">
+        <?php do_action('zenstarter_before_page_content'); ?>
+
+        <?php while (have_posts()) : the_post(); ?>
+            <article id="post-<?php the_ID(); ?>" <?php post_class('page-single'); ?>>
+                <?php if (has_post_thumbnail()) : ?>
+                    <div class="page-featured-image">
+                        <?php the_post_thumbnail('large', array(
+                            'loading' => 'eager',
+                            'alt' => the_title_attribute(array('echo' => false))
+                        )); ?>
+                    </div>
+                <?php endif; ?>
+
+                <header class="entry-header">
+                    <?php the_title('<h1 class="entry-title">', '</h1>'); ?>
+                </header>
+
+                <div class="entry-content">
+                    <?php
+                    the_content();
+                    wp_link_pages(array(
+                        'before' => '<div class="page-links">' . esc_html__('Pages:', 'zenstarter'),
+                        'after'  => '</div>',
+                    ));
+                    ?>
+                </div>
+            </article>
+
+            <?php
+            if (comments_open() || get_comments_number()) :
+                comments_template();
+            endif;
+            ?>
+        <?php endwhile; ?>
+
+        <?php do_action('zenstarter_after_page_content'); ?>
+    </div>
+</main>
+
+<?php
+if (is_active_sidebar('sidebar-right')) {
+    get_sidebar('right');
+}
+?>
+
+<?php get_footer(); ?>


### PR DESCRIPTION
## Summary
- implement left/right/full width page templates
- register new widget areas
- add sidebar templates
- document templates and sidebars
- update README section

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `composer lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846fed73a74832eba59518448cd653f